### PR TITLE
Add pineapple-flavoured version

### DIFF
--- a/verri/tasty.py
+++ b/verri/tasty.py
@@ -1,6 +1,6 @@
 import datetime as dt
 
-from verri import dates, git, version
+from verri import dates, environments, git, version
 
 
 @version
@@ -13,3 +13,20 @@ def strawberry():
         return f'{commit_ts.year}.{commit_ts.month}.{commit_ts.day}.{n}'
     else:
         return f'{commit_ts.year}.{commit_ts.month}.{commit_ts.day}.{n}+dirty'
+
+
+@version
+def pineapple():
+    ref = git.resolve()
+    commit_ts = dt.datetime.fromtimestamp(git.commit_ts(ref), tz=dt.timezone.utc)
+    commit_version = f'{commit_ts.year}.{commit_ts.month}.{commit_ts.day}'
+    n = git.num_commits_since(dates.midnight(commit_ts))
+    release = bool(environments.on_ci() and git.branch() == 'main' and git.clean())
+
+    match release, n:
+        case True, 1:
+            return commit_version
+        case True, n if n > 1:
+            return f'{commit_version}.{n - 1}'
+        case _:
+            return f'{commit_version}.dev{n}+{git.short(ref) if git.clean() else "dirty"}'


### PR DESCRIPTION
- release only when 'on CI', current branch is 'main' and repository is clean
- if release, use commit date with optional *n - 1* suffix
- otherwise, use development release with either short commit or dirty marking (depending on clean repository)