### PR TITLE
Have verri version itself

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "verri"
 version = "2026.3.29"
 description = "Verri version, such flavour, wow"
+readme = "README.md"
 authors = [
     {name = "Mattijs Ugen", email = "144798+akaIDIOT@users.noreply.github.com"},
 ]
@@ -10,6 +11,10 @@ dependencies = [
 ]
 requires-python = ">=3.10"
 license = {text = "EUPL-1.2"}
+
+[project.urls]
+homepage = "https://github.com/akaIDIOT/verri/"
+source = "https://github.com/akaIDIOT/verri/"
 
 [dependency-groups]
 check = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
+dynamic = ["version"]
 name = "verri"
-version = "2026.3.29"
+import-names = ["verri"]
 description = "Verri version, such flavour, wow"
 readme = "README.md"
 authors = [
@@ -25,6 +26,10 @@ test = [
     "coverage",
     "pytest",
 ]
+
+[tool.pdm.version]
+source = "call"
+getter = "verri.tasty:strawberry"
 
 [tool.pdm.scripts]
 all = {composite = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["pdm-backend"]
-build-backend = "pdm.backend"
-
 [project]
 name = "verri"
 version = "2026.3.29"
@@ -60,3 +56,9 @@ line-length = 120
 
 [tool.rumdl.MD013]
 reflow = true
+
+[build-system]
+# NB: using pdm-backend's own trick to allow a project depend on itself during a build
+#     normally, verri should be added to the requires field and the build-backend should be "pdm.backend"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend.intree"


### PR DESCRIPTION
Using pdm-backend's own trick to be able to depend on the project being built. Mark version to be dynamic, call `verri.tasty:strawberry` to resolve version.