### PR TITLE
Set checkout fetch-depth to 0 in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: pdm-project/setup-pdm@v4
         with:
           python-version: '3.14'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,5 @@ jobs:
           allow-python-prereleases: true
           cache: true
           cache-dependency-path: 'pylock.toml'
-      - name: Install test dependencies
-        run: pdm install --group test
-      - name: Run tests
-        run: pdm run test
+      - run: pdm install --group test
+      - run: pdm run test


### PR DESCRIPTION
Test runs show the expected version: "2026.3.29.11", released version shows up as "2026.3.29.1".

Fixes #3 